### PR TITLE
記事作成機能の実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V1
-    class ArticlesController < ApplicationController
+    class ArticlesController < BaseApiController
+      protect_from_forgery
+      skip_before_action :verify_authenticity_token
       before_action :set_article, only: %i[show update destroy]
 
       # GET /articles
@@ -19,13 +21,8 @@ module Api
       # POST /articles
       # POST /articles.json
       def create
-        @article = Article.new(article_params)
-
-        if @article.save
-          render :show, status: :created, location: @article
-        else
-          render json: @article.errors, status: :unprocessable_entity
-        end
+        @article = current_user.articles.create!(article_params)
+        render json: @article, serializer: Api::V1::ArticleSerializer
       end
 
       # PATCH/PUT /articles/1
@@ -53,7 +50,7 @@ module Api
 
         # Only allow a list of trusted parameters through.
         def article_params
-          params.fetch(:article, {})
+          params.require(:article).permit(:title, :body)
         end
     end
   end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,2 +1,5 @@
 class Api::V1::BaseApiController < ApplicationController
+  def current_user
+    @current_user ||= User.first
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,8 @@ module WondefulEditor
     # Don't generate system test files.
     config.generators.system_tests = nil
 
+    config.middleware.use ActionDispatch::Flash
+
     config.generators do |g|
       g.template_engine false
       g.javascripts false


### PR DESCRIPTION
- base_api_controller に current_user メソッドを定義
- 記事とログインユーザーを紐付け、title と body の変更のみを許可して、記事が作成されるように実装。