### PR TITLE
既存の API の修正

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,6 +1,7 @@
 module Api
   module V1
     class ArticlesController < BaseApiController
+      before_action :authenticate_user!, only: [:create, :update, :destroy]
       protect_from_forgery
       skip_before_action :verify_authenticity_token
       # before_action :set_article, only: %i[show update destroy]

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::BaseApiController < ApplicationController
-  def current_user
-    @current_user ||= User.first
-  end
+  alias_method :current_user, :current_api_v1_user
+  alias_method :authenticate_user!, :authenticate_api_v1_user!
+  alias_method :user_signed_in?, :api_v1_user_signed_in?
 end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -87,13 +87,12 @@ RSpec.describe "/articles", type: :request do
   end
 
   describe "POST /api/v1/articles" do
-    subject { post(api_v1_articles_path, params: params) }
-
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    subject { post(api_v1_articles_path, params: params, headers: headers) }
 
     context "適切なパラメーターを送信したとき" do
       let(:params) { { article: attributes_for(:article) } }
       let(:current_user) { create(:user) }
+      let(:headers) { current_user.create_new_auth_token }
 
       it "article のレコードを作成できる" do
         expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1)
@@ -110,6 +109,7 @@ RSpec.describe "/articles", type: :request do
     context "不適切なパラメーターを送信した時" do
       let(:params) { attributes_for(:article) }
       let(:current_user) { create(:user) }
+      let(:headers) { current_user.create_new_auth_token }
 
       it "エラーする" do
         expect { subject }.to raise_error(ActionController::ParameterMissing)
@@ -118,12 +118,11 @@ RSpec.describe "/articles", type: :request do
   end
 
   describe "PATCH /api/v1/articles/:id" do
-    subject { patch(api_v1_article_path(article.id), params: params) }
-
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    subject { patch(api_v1_article_path(article.id), params: params, headers: headers) }
 
     let(:current_user) { create(:user) }
     let(:params) { { article: { title: Faker::Lorem.word, created_at: 1.day.ago } } }
+    let(:headers) { current_user.create_new_auth_token }
 
     context "自分が所持している記事のレコードを更新しようとした時" do
       let(:article) { create(:article, user: current_user) }
@@ -147,11 +146,10 @@ RSpec.describe "/articles", type: :request do
   end
 
   describe "DELETE /api/v1/articles/:id" do
-    subject { delete(api_v1_article_path(article.id)) }
-
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    subject { delete(api_v1_article_path(article.id), headers: headers) }
 
     let(:current_user) { create(:user) }
+    let(:headers) { current_user.create_new_auth_token }
 
     context "指定した id の記事が存在するとき" do
       let!(:article) { create(:article, user: current_user) }


### PR DESCRIPTION
- ダミーコードの current_user メソッドを削除
- devise-token-auth で提供されているメソッドが使えるように実装
- authenticate_user! で create,update,destroy をログインユーザーのみができるように実装