### PR TITLE
既存のAPIの修正

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -9,14 +9,14 @@ module Api
       # GET /articles
       # GET /articles.json
       def index
-        @articles = Article.all.order(updated_at: :desc)
+        @articles = Article.where(status: 1).order(updated_at: :desc)
         render json: @articles, each_serializer: Api::V1::ArticlePreviewSerializer
       end
 
       # GET /articles/1
       # GET /articles/1.json
       def show
-        @article = Article.find(params[:id])
+        @article = Article.where(status: 1).find(params[:id])
         render json: @article, serializer: Api::V1::ArticleSerializer
       end
 
@@ -52,7 +52,7 @@ module Api
 
         # Only allow a list of trusted parameters through.
         def article_params
-          params.require(:article).permit(:title, :body)
+          params.require(:article).permit(:title, :body, :status)
         end
     end
   end

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,4 +1,4 @@
 class Api::V1::ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :updated_at
+  attributes :id, :title, :body, :status, :updated_at
   belongs_to :user, serializer: Api::V1::UserSerializer
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :article do
     title { Faker::Lorem.word }
     body { Faker::Lorem.sentence }
-    status { 0 }
+    status { "draft" }
     user
 
     trait :with_comment do


### PR DESCRIPTION
- 記事一覧、記事詳細画面で、公開状態の記事のみを表示するように実装
- 記事作成、記事更新で記事の状態を選択できるように実装
- それぞれのテストを実装